### PR TITLE
Fix preview background colors

### DIFF
--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -451,11 +451,11 @@ export default {
     }
 
     &:hover {
-      background-color: #32343e;
+      background-color: #2a2a34;
       cursor: pointer;
 
       img {
-        background-color: #32343e;
+        background-color: #2a2a34;
       }
 
       .site__url {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -10,7 +10,7 @@ $white_color: #21212a;
 
 $actions_ribbon_background_color: #272831;
 $search_nav_border_color: #707070;
-$thumbnail_background_color: #2c2e37;
+$thumbnail_background_color: #272831;
 $preview_description_font_color: #90909c;
 $buttons_background: #1d1e27;
 


### PR DESCRIPTION
It appears that background colors were off a little. Fixed according the design - in the design files was used opacity 50% which was misleading when picking the color values, so had to adjust