### PR TITLE
Restore Scroll position when navigated back

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,8 @@
 <template>
-  <div id="app">
+  <div
+    id="app"
+    @mousedown="saveScrollPosition()"
+  >
     <div
       ref="wrapper"
       class="min-h-screen wrapper"
@@ -10,7 +13,9 @@
       >
         Alert - unsupported browser
       </div>
-      <router-view :key="$route.fullPath" />
+      <keep-alive :max="5">
+        <router-view :key="$route.fullPath" />
+      </keep-alive>
     </div>
   </div>
 </template>
@@ -29,6 +34,7 @@ export default {
   data() {
     return {
       page: 1,
+      savedScrolls: [],
     };
   },
   computed: {
@@ -48,6 +54,14 @@ export default {
       this.$router.push({
         name: 'maintenance',
       });
+    });
+    this.$router.afterEach((to) => {
+      setTimeout(
+        () => {
+          document.scrollingElement.scrollTop = this.savedScrolls[to.fullPath] || 0;
+        },
+        100,
+      );
     });
   },
   methods: {
@@ -111,6 +125,9 @@ export default {
       await this.reloadData();
 
       this.removeLoading('initial');
+    },
+    saveScrollPosition() {
+      this.savedScrolls[this.$route.fullPath] = document.scrollingElement.scrollTop;
     },
   },
 };

--- a/src/components/layout/Navigation.vue
+++ b/src/components/layout/Navigation.vue
@@ -8,7 +8,10 @@
         >
       </router-link>
     </div>
-    <div class="navigation__item home">
+    <div
+      class="navigation__item home"
+      @click="scrollTop()"
+    >
       <router-link :to="{ name: 'home' }">
         <div class="navigation__item__image" />
         <span>Home</span>
@@ -29,6 +32,7 @@
     <div
       v-if="isLoggedIn"
       class="navigation__item profile"
+      @click="scrollTop()"
     >
       <router-link :to="{ name: 'user-profile', params: { address: account } }">
         <div class="navigation__item__image" />
@@ -38,6 +42,7 @@
     <div
       v-else
       class="navigation__item profile"
+      @click="scrollTop()"
     >
       <router-link :to="{ name: 'create-profile' }">
         <div class="navigation__item__image" />
@@ -60,6 +65,11 @@ export default {
   name: 'Navigation',
   computed: {
     ...mapGetters(['account', 'isLoggedIn']),
+  },
+  methods: {
+    scrollTop() {
+      document.scrollingElement.scrollTop = 0;
+    },
   },
 };
 </script>


### PR DESCRIPTION
Please check for misbehavior

Since it is kind of hackish I will describe a little:

First trick I used is to use `keep-alive` for views (we don't have much of these, so I guess no big resource waste, tough I put a reasonable limit there. This will keep the page size and allows to use scrollTo (else we would have unreachable positions until all desired pages are loaded). Also speeds up the interface as a bonus.

Scroll position is saved when clicked (in fact I had to use mousedown) somewhere (unfortunately any other vue events always return 0 for scroll positions, i guess because `window` is not yet updated with scroll data). 

When you navigate to any url, scroll will be restored if has been visited. What we actually try to achieve. Tough there is a side-effect: Restore position happens on main nav clicking too. 

However this side-effect has the drawback that it will be harder to get on top. Since we are not sure for the intentions of the user (he might expect to get on the same position, or might as well simply go to top), so on the second click of the current route I made a handler that will scroll to top. 

There is a trick that is used for that second click. It is how `router-link` appears to work - if navigate to different route it block the click handler (which simply scrolls to top), but if you are already on the route it doesn't (so scrolling to top is triggered).

I also considered vue's native `scrollBehavior`, but we can't use it because it only works with router's `mode: history` (while we use 'hash')