### PR TITLE
Deeplink for Tip action on mobile

### DIFF
--- a/src/components/TipInput.vue
+++ b/src/components/TipInput.vue
@@ -163,17 +163,17 @@ export default {
       if (this.userAddress) {
         url = new URL(`${process.env.VUE_APP_WALLET_URL}/tip`);
         url.searchParams.set('url',
-          `${encodeURIComponent(`https://superhero.com/#/user-profile/${this.userAddress}`)}`);
+          encodeURIComponent(`https://superhero.com/#/user-profile/${this.userAddress}`));
       } else if (this.isRetip) {
         url = new URL(`${process.env.VUE_APP_WALLET_URL}/retip`);
         url.searchParams.set('id', this.tip.id);
       } else {
         url = new URL(`${process.env.VUE_APP_WALLET_URL}/tip`);
         url.searchParams.set('url',
-          `${encodeURIComponent(`https://superhero.com/#/tip/${this.tip.id}`)}`);
+          encodeURIComponent(`https://superhero.com/#/tip/${this.tip.id}`));
       }
-      url.searchParams.set('x-success', `${encodeURIComponent(window.location)}`);
-      url.searchParams.set('x-cancel', `${encodeURIComponent(window.location)}`);
+      url.searchParams.set('x-success', encodeURIComponent(window.location));
+      url.searchParams.set('x-cancel', encodeURIComponent(window.location));
       return url;
     },
     isMessageValid() {

--- a/src/components/TipInput.vue
+++ b/src/components/TipInput.vue
@@ -11,7 +11,7 @@
   </a>
   <a
     v-else-if="USE_DEEP_LINKS && userAddress"
-    :href="userProfileDeepLink"
+    :href="deepLink"
     target="_blank"
     class="tip__content"
     @click.stop
@@ -152,14 +152,6 @@ export default {
       }
       return null;
     },
-    userProfileDeepLink() {
-      const url = new URL(`${process.env.VUE_APP_WALLET_URL}/tip`);
-      url.searchParams.set('url',
-        `${encodeURIComponent(`https://superhero.com/#/user-profile/${this.userAddress}`)}`);
-      url.searchParams.set('x-success', window.location);
-      url.searchParams.set('x-cancel', window.location);
-      return url;
-    },
     derivedUserTipStats() {
       if (!this.stats || !this.stats.by_url) {
         return null;
@@ -167,10 +159,21 @@ export default {
       return this.stats.by_url.find((tipStats) => tipStats.url === `https://superhero.com/#/user-profile/${this.userAddress}`);
     },
     deepLink() {
-      const url = new URL(`${process.env.VUE_APP_WALLET_URL}/${this.isRetip ? 'retip' : 'tip'}`);
-      url.searchParams.set('id', this.tip.id);
-      url.searchParams.set('x-success', window.location);
-      url.searchParams.set('x-cancel', window.location);
+      let url = '';
+      if (this.userAddress) {
+        url = new URL(`${process.env.VUE_APP_WALLET_URL}/tip`);
+        url.searchParams.set('url',
+          `${encodeURIComponent(`https://superhero.com/#/user-profile/${this.userAddress}`)}`);
+      } else if (this.isRetip) {
+        url = new URL(`${process.env.VUE_APP_WALLET_URL}/retip`);
+        url.searchParams.set('id', this.tip.id);
+      } else {
+        url = new URL(`${process.env.VUE_APP_WALLET_URL}/tip`);
+        url.searchParams.set('url',
+          `${encodeURIComponent(`https://superhero.com/#/tip/${this.tip.id}`)}`);
+      }
+      url.searchParams.set('x-success', `${encodeURIComponent(window.location)}`);
+      url.searchParams.set('x-cancel', `${encodeURIComponent(window.location)}`);
       return url;
     },
     isMessageValid() {


### PR DESCRIPTION
Deep Links are set as per this documentation:
https://github.com/aeternity/superhero-wallet/blob/932e1b6926699174bd1583f5247163ca09bef4f8/tests/pages/index.html

The issue with empty url field when "tip" action is executed, still persists.

ref #437
