### PR TITLE
util: Don't encode comment content twice

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -64,21 +64,11 @@ export const IDENTICON_CONFIG = {
   backColor: '#12121bff',
 };
 
-export const createDeepLinkUrl = ({
-  type, id, text, parentId,
-}) => {
+export const createDeepLinkUrl = ({ type, ...params }) => {
   const url = new URL(`${process.env.VUE_APP_WALLET_URL}/${type}`);
-  if (parentId) {
-    url.searchParams.set('parentId', parentId);
-  }
-  if (id) {
-    url.searchParams.set('id', id);
-  }
-  if (text) {
-    url.searchParams.set('text', encodeURIComponent(text));
-  }
-  url.searchParams.set('x-success', encodeURIComponent(window.location));
-  url.searchParams.set('x-cancel', encodeURIComponent(window.location));
+  Object.entries(params).forEach(([name, value]) => url.searchParams.set(name, value));
+  url.searchParams.set('x-success', window.location);
+  url.searchParams.set('x-cancel', window.location);
   return url;
 };
 


### PR DESCRIPTION
The problem is that a comment like "test comment" becomes "test%20comment" after creation.

As I understand, this happens because firstly `encodeURIComponent` transforms "test comment" into "test%20comment" and then `searchParams.set` assumes that payload is not encoded and transforms "test%20comment" into "test%2520comment". So, I guess that it is not necessary to call `encodeURIComponent` before passing a value into `searchParams.set`.