### PR TITLE
Improve consistency of tip icons

### DIFF
--- a/src/components/AeAmount.vue
+++ b/src/components/AeAmount.vue
@@ -30,7 +30,12 @@ export default {
 
 <style lang="scss" scoped>
 .ae {
-  padding-left: 2px;
   color: $secondary_color;
+  padding-left: 2px;
+}
+
+.ae-amount {
+  color: $standard_font_color;
+  line-height: 1;
 }
 </style>

--- a/src/components/AeAmountFiat.vue
+++ b/src/components/AeAmountFiat.vue
@@ -31,10 +31,12 @@ export default {
 
 <style lang="scss" scoped>
 .ae-amount-fiat {
-  display: inline-block;
+  display: flex;
+  align-items: center;
 
   .currency-value {
     font-size: 0.7rem;
+    color: $light_font_color;
     margin-left: 0.1rem;
   }
 }

--- a/src/components/TipInput.vue
+++ b/src/components/TipInput.vue
@@ -355,12 +355,16 @@ export default {
 <style lang="scss" scoped>
   .tip__content {
     position: relative;
+    display: flex;
+    align-items: center;
+    line-height: 1;
 
     img {
       height: 0.7rem;
       margin-right: 0.3rem;
-      margin-bottom: 0.1rem;
+      margin-bottom: 0.05rem;
       width: 1rem;
+      flex: 0 0 1rem;
     }
 
     &:hover img {
@@ -409,13 +413,8 @@ export default {
     }
 
     .tip__content.user {
-      .tip__icon {
-        margin-top: 0.2rem;
-      }
-
-      &:hover {
-        cursor: pointer;
-      }
+      cursor: pointer;
+      margin-top: 0.1rem;
     }
 
     .tip-user-text {

--- a/src/components/layout/Overview.vue
+++ b/src/components/layout/Overview.vue
@@ -118,6 +118,7 @@ export default {
     display: flex;
     flex-direction: column;
     color: $standard_font_color;
+    align-items: flex-start;
 
     .currency-value {
       font-size: 0.7rem;

--- a/src/components/layout/RightSection.vue
+++ b/src/components/layout/RightSection.vue
@@ -178,10 +178,7 @@ export default {
           & > div {
             &.ae-amount-fiat {
               width: 52%;
-
-              .ae-amount {
-                color: $standard_font_color;
-              }
+              justify-content: flex-end;
             }
 
             width: 48%;

--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -322,14 +322,7 @@ export default {
   .tip__footer_wrapper {
     display: flex;
     flex-wrap: wrap;
-  }
-
-  // separator
-  .tip__footer_wrapper::after {
-    content: '';
-    flex-basis: 1rem;
-    height: 1rem;
-    order: 3;
+    justify-content: center;
   }
 
   .tip__comments,
@@ -338,7 +331,7 @@ export default {
     display: flex;
     flex: 0 0 auto;
     height: 1rem;
-    margin-right: 1rem;
+    cursor: pointer;
     position: relative;
     width: max-content;
 
@@ -348,10 +341,6 @@ export default {
   }
 
   .tip__comments {
-    margin: 0 auto;
-    cursor: pointer;
-    order: 4;
-
     img {
       height: 1rem;
     }
@@ -453,7 +442,8 @@ export default {
         height: 1rem;
         margin-right: 0.335rem;
         padding: 0.135rem 0;
-        flex: 0;
+        flex: 0 0 1rem;
+        vertical-align: initial;
       }
 
       a {
@@ -464,6 +454,10 @@ export default {
 
         &:hover {
           text-decoration: underline;
+
+          img {
+            filter: brightness(1.3);
+          }
         }
       }
     }

--- a/src/views/UserProfileView.vue
+++ b/src/views/UserProfileView.vue
@@ -487,11 +487,14 @@ export default {
         color: $tip_note_color;
       }
 
-      .stat-value,
-      .stat-value /deep/ .currency-value {
+      .stat-value {
         font-size: 0.9rem;
         color: $secondary_color;
         font-weight: 400;
+      }
+
+      .stat-value .currency-value {
+        font-size: 80%;
       }
     }
   }
@@ -796,10 +799,6 @@ export default {
     .tip__user {
       top: -1.25rem;
       right: 6rem;
-    }
-
-    .stats .stat .stat-value {
-      font-size: 0.6rem;
     }
   }
 }


### PR DESCRIPTION
close #511 

In case someone is interested: It appears that `flex: 0` is misinterpreted as `0 0 0%` instead of expected `0 0 auto` which makes the icon behave weirdly (probably because dimensions are also implicitly set), so apparently `flex:` should be used with its full syntax (despite it is essentially a shortcut).

Also improved the consistency for alignment of amounts and icons (and cleaned up some leftovers from refactoring fiat component)