### PR TITLE
Footer is not trimmed on smaller screens

### DIFF
--- a/src/components/layout/FooterSection.vue
+++ b/src/components/layout/FooterSection.vue
@@ -129,7 +129,7 @@ export default {
     }
   }
 
-  @media (max-width: 1280px) {
+  @media (max-height: 595px) {
     p {
       margin-bottom: 0.4rem;
     }

--- a/src/components/layout/FooterSection.vue
+++ b/src/components/layout/FooterSection.vue
@@ -128,4 +128,21 @@ export default {
       }
     }
   }
+
+  @media (max-width: 1280px) {
+    p {
+      margin-bottom: 0.4rem;
+    }
+
+    .footer {
+      .footer-btns {
+        margin-bottom: 0.4rem;
+      }
+
+      .terms-links {
+        margin-top: 0.4rem;
+      }
+    }
+  }
+
 </style>


### PR DESCRIPTION
Please review the footer behaviour on bigger resolutions - 1280px+ screens. An adjustment may be needed.