### PR TITLE
createDeepLinkUrl: Omit undefined and null values

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -80,7 +80,9 @@ export const AVATAR_CONFIG = {
 
 export const createDeepLinkUrl = ({ type, ...params }) => {
   const url = new URL(`${process.env.VUE_APP_WALLET_URL}/${type}`);
-  Object.entries(params).forEach(([name, value]) => url.searchParams.set(name, value));
+  Object.entries(params)
+    .filter(([, value]) => ![undefined, null].includes(value))
+    .forEach(([name, value]) => url.searchParams.set(name, value));
   url.searchParams.set('x-success', window.location);
   url.searchParams.set('x-cancel', window.location);
   return url;


### PR DESCRIPTION
@petbaik send me the error report:
```
{
  "id":25,
  "appVersion":"0.0.26",
  "browser":"{\"name\":\"chrome\",\"version\":\"81.0.4044\",\"os\":\"Windows 10\"}",
  "error":"{\"message\":\"Could not find parent comment with id null\",\"type\":\"vue-error\",\"payload\":{\"id\":1226,\"text\":\"Thank you for your support and checking out my music!\"},\"info\":\"v-on handler (Promise/async)\"}",
  "platform":"web",
  "description":"Could not comment under a post!",
  "time":"1589902211663.0",
  "createdAt":"2020-05-19 15:30:34.629 +00:00",
  "updatedAt":"2020-05-19 15:30:34.629 +00:00"
}
```

The problem is when the user tries to create a root comment, superhero-ui redirects him via deeplink with `parentId=undefined` that the wallet trying to parse as a number. It completely breaks commenting in that case.