### PR TITLE
App: Subscribe on events before initialLoad

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,7 +44,6 @@ export default {
     },
   },
   async created() {
-    await this.initialLoad();
     EventBus.$on('reloadData', () => {
       this.reloadData();
     });
@@ -54,6 +53,7 @@ export default {
         name: 'maintenance',
       }).catch((err) => { console.error(err); });
     });
+    await this.initialLoad();
     this.$router.afterEach((to) => {
       setTimeout(
         () => {


### PR DESCRIPTION
fixes #648 
In case we don't have extension or we don't init it with seed phrase the `created` of an App.vue got stucked on `initialLoad` method, because it is frozen on scanning for the wallet till it find it. I propose to subscribe for the events first (before initialLoad).