### PR TITLE
TipRecord: Avoid extra rerendering

### DIFF
--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    :key="key"
     class="tip__record row"
     @click="goToTip(tip.id)"
   >
@@ -175,7 +174,6 @@ export default {
   },
   data() {
     return {
-      key: `${this.tip.id}_${new Date().getTime()}`,
       showSuccessModal: false,
     };
   },


### PR DESCRIPTION
from the discussion in #345 looks like that it depends on #708 
I have not tested this change carefully, but I think we should get rid of this