### PR TITLE
Rename state.account to state.address

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,7 @@ export default {
   name: 'App',
   components: { MobileNavigation, LeftSection, RightSection },
   computed: {
-    ...mapState(['account']),
+    ...mapState(['address']),
     isSupportedBrowser() {
       const browser = detect();
       return !IS_MOBILE_DEVICE && (browser && !supportedBrowsers.includes(browser.name));
@@ -78,8 +78,8 @@ export default {
         this.$store.dispatch('backend/reloadPrices'),
       ]);
 
-      if (this.account) {
-        const balance = await client.balance(this.account).catch(() => 0);
+      if (this.address) {
+        const balance = await client.balance(this.address).catch(() => 0);
         this.updateBalance(Util.atomsToAe(balance).toFixed(2));
       }
 
@@ -102,7 +102,7 @@ export default {
       await initClient();
       await this.reloadData();
       this.removeLoading('initial');
-      if (this.account) {
+      if (this.address) {
         this.removeLoading('wallet');
         this.fetchUserData();
       }
@@ -116,7 +116,7 @@ export default {
       }
       const balance = await client.balance(address).catch(() => 0);
       this.setLoggedInAccount({
-        account: address,
+        address,
         balance: Util.atomsToAe(balance).toFixed(2),
       });
       this.fetchUserData();

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -31,8 +31,8 @@ export default {
         ? new Avatars(sprites, AVATAR_CONFIG).create(name)
         : `data:image/svg+xml;base64,${btoa(jdenticon.toSvg(this.address, 32))}`;
     },
-    profileImageUrl({ account, profile }) {
-      const key = account === this.address && profile?.signature?.slice(0, 5);
+    profileImageUrl({ address, profile }) {
+      const key = address === this.address && profile?.signature?.slice(0, 5);
       return `${Backend.getProfileImageUrl(this.address)}?${key || ''}`;
     },
   }),

--- a/src/components/ListOfTipsAndComments.vue
+++ b/src/components/ListOfTipsAndComments.vue
@@ -120,9 +120,11 @@ export default {
     userPinnedItems: [],
   }),
   computed: {
-    ...mapState(['loading', 'account']),
+    ...mapState(['loading']),
+    ...mapState({ currentAddress: 'address' }),
     pinnedItems() {
-      return this.address === this.account ? this.$store.state.pinnedItems : this.userPinnedItems;
+      return this.address === this.currentAddress
+        ? this.$store.state.pinnedItems : this.userPinnedItems;
     },
     showNoResultsMsg() {
       return this.activeTab === 'comments'
@@ -139,7 +141,7 @@ export default {
       this.reloadData();
     });
 
-    if (this.address !== this.account) {
+    if (this.address !== this.currentAddress) {
       Backend.getPinnedItems(this.address)
         .then((pinnedItems) => {
           this.userPinnedItems = pinnedItems;

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -33,7 +33,7 @@ export default {
     showSubmitButton: Boolean,
     submitButtonTitle: { type: String, default: '' },
   },
-  computed: mapState({ address: 'account' }),
+  computed: mapState(['address']),
   mounted() {
     autosize(this.$refs.input);
   },

--- a/src/components/TipInput.vue
+++ b/src/components/TipInput.vue
@@ -84,14 +84,14 @@ export default {
     message: '',
   }),
   computed: {
-    ...mapState(['useSdkWallet', 'account']),
+    ...mapState(['useSdkWallet', 'address']),
     ...mapGetters('backend', ['minTipAmount']),
     ...mapState('backend', {
       tipUrlStats({ stats }) {
         const urlStats = stats && stats.by_url.find(({ url }) => url === this.tipUrl);
         if (!urlStats) return {};
         return {
-          isTipped: urlStats.senders.includes(this.account),
+          isTipped: urlStats.senders.includes(this.address),
           amount: urlStats.total_amount,
         };
       },

--- a/src/components/layout/Navigation.vue
+++ b/src/components/layout/Navigation.vue
@@ -17,7 +17,7 @@
     </RouterLink>
     <RouterLink
       v-if="isLoggedIn"
-      :to="{ name: 'user-profile', params: { address: account } }"
+      :to="{ name: 'user-profile', params: { address } }"
     >
       <IconUser />
       {{ $t('components.layout.Navigation.MyProfile') }}
@@ -65,7 +65,7 @@ export default {
   },
   computed: {
     ...mapGetters(['isLoggedIn']),
-    ...mapState(['account']),
+    ...mapState(['address']),
   },
 };
 </script>

--- a/src/components/layout/RightSectionWallet.vue
+++ b/src/components/layout/RightSectionWallet.vue
@@ -17,8 +17,8 @@
       :src="walletUrl"
     />
     <template v-else-if="isLoggedIn">
-      <div class="account">
-        {{ account }}
+      <div class="address">
+        {{ address }}
       </div>
       <div class="not-bootstrap-row">
         <AeAmount :amount="balance" />
@@ -48,7 +48,7 @@ export default {
   }),
   computed: {
     ...mapGetters(['isLoggedIn']),
-    ...mapState(['balance', 'account', 'useIframeWallet', 'selectedCurrency']),
+    ...mapState(['balance', 'address', 'useIframeWallet', 'selectedCurrency']),
     ...mapState({
       currencyDropdownOptions({ backend: { prices }, balance }) {
         return Object.entries(prices).map(([currency, price]) => ({
@@ -90,7 +90,7 @@ export default {
     }
   }
 
-  .account {
+  .address {
     color: $light_font_color;
     font-size: 0.52rem;
     position: relative;

--- a/src/components/layout/sendTip/SendTip.vue
+++ b/src/components/layout/sendTip/SendTip.vue
@@ -98,7 +98,7 @@ export default {
   computed: {
     ...mapGetters(['isLoggedIn']),
     ...mapGetters('backend', ['minTipAmount']),
-    ...mapState(['loading', 'account']),
+    ...mapState(['loading']),
     isSendTipDataValid() {
       const urlRegex = /(https?:\/\/)?([\w-])+\.{1}([a-zA-Z]{2,63})([/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)/g;
       // TODO: better validation

--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -45,7 +45,7 @@
                 {{ $t('components.tipRecords.TipRecord.claim') }}
               </div>
               <div
-                v-if="account"
+                v-if="address"
                 @click="pinOrUnPinTip"
               >
                 {{
@@ -179,7 +179,7 @@ export default {
     };
   },
   computed: {
-    ...mapState(['account', 'useSdkWallet']),
+    ...mapState(['address', 'useSdkWallet']),
     ...mapState({
       isTipPinned({ pinnedItems }) {
         return pinnedItems.some(({ id }) => id === this.tip.id);
@@ -210,7 +210,7 @@ export default {
     async claim() {
       await Backend.claimFromUrl({
         url: this.tip.url,
-        address: this.account,
+        address: this.address,
       });
     },
     async pinOrUnPinTip() {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,7 +10,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    account: null,
+    address: null,
     balance: 0,
     profile: {},
     pinnedItems: [],
@@ -32,25 +32,25 @@ export default new Vuex.Store({
   },
   mutations,
   actions: {
-    async updateUserProfile({ commit, state: { account } }) {
-      commit('setUserProfile', await Backend.getProfile(account));
+    async updateUserProfile({ commit, state: { address } }) {
+      commit('setUserProfile', await Backend.getProfile(address));
     },
-    async updatePinnedItems({ commit, state: { account } }) {
-      commit('setPinnedItems', await Backend.getPinnedItems(account));
+    async updatePinnedItems({ commit, state: { address } }) {
+      commit('setPinnedItems', await Backend.getPinnedItems(address));
     },
   },
   getters: {
-    isLoggedIn: (state) => !!state.account,
+    isLoggedIn: (state) => !!state.address,
   },
   modules: { backend },
   plugins: [
     persistState(
       (state) => state,
       ({
-        selectedCurrency, account, balance,
+        selectedCurrency, address, balance,
       }) => ({
         selectedCurrency,
-        account,
+        address,
         balance,
       }),
     ),

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -2,13 +2,13 @@ import Vue from 'vue';
 import { mergeWith } from 'lodash-es';
 
 export default {
-  setLoggedInAccount(state, { account, balance }) {
-    state.account = account;
+  setLoggedInAccount(state, { address, balance }) {
+    state.address = address;
     state.balance = balance;
   },
   resetState(state) {
     state.useSdkWallet = false;
-    state.account = null;
+    state.address = null;
     state.balance = 0;
     state.profile = {};
   },

--- a/src/utils/backendAuthMixin.js
+++ b/src/utils/backendAuthMixin.js
@@ -4,7 +4,10 @@ import { createDeepLinkUrl } from './util';
 import { client } from './aeternity';
 
 export default (ignoreCallInQuery) => ({
-  computed: mapState(['useSdkWallet', 'account']),
+  computed: mapState({
+    useSdkWallet: 'useSdkWallet',
+    currentAddress: 'address',
+  }),
   ...!ignoreCallInQuery && {
     async beforeRouteEnter(to, from, next) {
       const {
@@ -28,10 +31,10 @@ export default (ignoreCallInQuery) => ({
   },
   methods: {
     async backendAuth(method, arg, to) {
-      const { challenge } = await Backend[method](this.account, arg);
+      const { challenge } = await Backend[method](this.address, arg);
       if (this.useSdkWallet) {
         const signature = await client.signMessage(challenge);
-        await Backend[method](this.account, { challenge, signature });
+        await Backend[method](this.address, { challenge, signature });
         return;
       }
 
@@ -40,7 +43,7 @@ export default (ignoreCallInQuery) => ({
       window.location = createDeepLinkUrl({
         type: 'sign-message',
         message: challenge,
-        'x-success': `${url}?method=${method}&address=${this.account}&challenge=${challenge}&signature={signature}`,
+        'x-success': `${url}?method=${method}&address=${this.address}&challenge=${challenge}&signature={signature}`,
       });
     },
   },

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -11,10 +11,10 @@
       />
       <div
         class="profile__header"
-        :class="{ 'profile__editable': account === address }"
+        :class="{ 'profile__editable': currentAddress === address }"
       >
         <div
-          v-if="account === address"
+          v-if="currentAddress === address"
           class="edit__buttons"
         >
           <label
@@ -61,7 +61,7 @@
         <div class="profile__image">
           <Avatar :address="address" />
           <TipInput
-            v-if="account !== address"
+            v-if="currentAddress !== address"
             :user-address="address"
             class="avatar__button profile__button"
           />
@@ -116,7 +116,7 @@
               class="location"
             >
               <img
-                v-if="profile.location.length || account === address"
+                v-if="profile.location.length || currentAddress === address"
                 src="../assets/location.svg"
               >
               <input
@@ -127,7 +127,7 @@
                 :placeholder="$t('views.UserProfileView.LocationPlaceholder')"
               >
               <span
-                v-if="!editMode && (profile.location.length || account === address)"
+                v-if="!editMode && (profile.location.length || currentAddress === address)"
               >
                 {{
                   profile.location.length
@@ -254,7 +254,8 @@ export default {
     };
   },
   computed: {
-    ...mapState(['useSdkWallet', 'account', 'chainNames']),
+    ...mapState(['useSdkWallet', 'chainNames']),
+    ...mapState({ currentAddress: 'address' }),
     userChainName() {
       return this.chainNames[this.address];
     },
@@ -350,7 +351,7 @@ export default {
       await this.backendAuth('sendProfileData', {
         biography: this.profile.biography,
         location: this.profile.location,
-        author: this.account,
+        author: this.currentAddress,
       });
       await this.resetEditedValues();
     },


### PR DESCRIPTION
I think this naming is more consistent with other projects. I propose to assume account an object with `address`, `balance`, `name`, and other keys like them.