### PR TITLE
Extended timeout

### DIFF
--- a/src/components/layout/sendTip/SendTip.vue
+++ b/src/components/layout/sendTip/SendTip.vue
@@ -111,12 +111,12 @@ export default {
         .then(async () => {
           await Backend.cacheInvalidateTips().catch(console.error);
           this.clearTipForm();
-          EventBus.$emit('reloadData');
           this.$store.dispatch('modals/open', {
             name: 'success',
             title: this.$t('components.layout.SendTip.SuccessHeader'),
             body: this.$t('components.layout.SendTip.SuccessText'),
           });
+          setTimeout(() => EventBus.$emit('reloadData'), 5000);
         }).catch((e) => {
           this.sendingTip = false;
           if (e.code && e.code === 4) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -21,7 +21,7 @@ export const wrapTry = async (promise) => {
         return null;
       }),
       new Promise(((resolve, reject) => {
-        setTimeout(reject, 10000, new Error('Request is cancelled by timeout'));
+        setTimeout(reject, 12000, new Error('Request is cancelled by timeout'));
       })),
     ]);
   } catch (err) {


### PR DESCRIPTION
Fixes #780 

Extended requests timeout and after sending tip the reloading is delayed, to ensure enough time the back-end to process it.