### PR TITLE
SendComment: Preserve comment if it wasn't being sent

### DIFF
--- a/src/components/SendComment.vue
+++ b/src/components/SendComment.vue
@@ -55,10 +55,10 @@ export default {
           parentId: this.parentId,
         });
         EventBus.$emit('reloadData');
+        this.comment = '';
       } catch (e) {
         if (e.message !== 'Operation rejected by user') handleUnknownError(e);
       } finally {
-        this.comment = '';
         this.setLoading = false;
       }
     },


### PR DESCRIPTION
It can be super annoying to type it again if I'm trying to send it in a different way/to make one more attempt

#822 