### PR TITLE
vue cli: Drop @ alias

### DIFF
--- a/src/components/__tests__/Loading.js
+++ b/src/components/__tests__/Loading.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import Loading from '@/components/Loading.vue';
+import Loading from '../Loading.vue';
 
 describe('Loading', () => {
   it('is visible', () => {

--- a/src/utils/aeternity.js
+++ b/src/utils/aeternity.js
@@ -5,7 +5,7 @@ import {
 } from '@aeternity/aepp-sdk/es';
 import Detector from '@aeternity/aepp-sdk/es/utils/aepp-wallet-communication/wallet-detector';
 import BrowserWindowMessageConnection from '@aeternity/aepp-sdk/es/utils/aepp-wallet-communication/connection/browser-window-message';
-import { CONTRACT_ADDRESS, COMPILER_URL, NODE_URL } from '@/config/constants';
+import { CONTRACT_ADDRESS, COMPILER_URL, NODE_URL } from '../config/constants';
 import TIPPING_INTERFACE from '../contracts/TippingInterface.aes';
 import { EventBus } from './eventBus';
 import store from '../store';

--- a/vue.config.js
+++ b/vue.config.js
@@ -14,8 +14,8 @@ module.exports = {
       sass: {
         // Global includes - will be prepended in every scss file (including components)
         prependData: `
-          @import "@/styles/_variables";
-          @import "@/styles/_mixins";
+          @import "${path.resolve(__dirname, 'src/styles/_variables.scss')}";
+          @import "${path.resolve(__dirname, 'src/styles/_mixins.scss')}";
         `,
       },
     },
@@ -66,6 +66,7 @@ module.exports = {
         return [definitions];
       })
       .end()
+      .resolve.alias.delete('@').parent.parent
       .module
       .rule('aes')
       .test(/\.aes$/)


### PR DESCRIPTION
Pros to do that:
- remove one way to write inconsistent (until it is not enforced by linter)
- `@` imports is not a standard, if somebody would like to import our code he has to set up our's imports parsing by himself

Cons:
- in some cases imports is longer (I think is not a big deal if the project is good enough structured)
