### PR TITLE
Increase iframe wallet timeout, add a button to enable it manually

### DIFF
--- a/src/components/layout/FooterSection.vue
+++ b/src/components/layout/FooterSection.vue
@@ -58,10 +58,7 @@
       v-if="!isLoggedIn"
       class="login-footer"
     >
-      <OutlinedButton
-        :to="addressDeepLink"
-        :title="$t('components.layout.FooterSection.LoginWithWallet')"
-      >
+      <OutlinedButton :to="addressDeepLink">
         {{ $t('components.layout.FooterSection.LoginWithWallet') }}
       </OutlinedButton>
     </div>

--- a/src/components/layout/RightSectionWallet.vue
+++ b/src/components/layout/RightSectionWallet.vue
@@ -30,6 +30,12 @@
         />
       </div>
     </template>
+    <OutlinedButton
+      v-else
+      @click="enableIframeWallet"
+    >
+      {{ $t('components.layout.FooterSection.LoginWithWallet') }}
+    </OutlinedButton>
   </div>
 </template>
 
@@ -39,9 +45,12 @@ import BigNumber from 'bignumber.js';
 import AeAmount from '../AeAmount.vue';
 import Dropdown from '../Dropdown.vue';
 import RightSectionTitle from './RightSectionTitle.vue';
+import OutlinedButton from '../OutlinedButton.vue';
 
 export default {
-  components: { RightSectionTitle, AeAmount, Dropdown },
+  components: {
+    RightSectionTitle, AeAmount, Dropdown, OutlinedButton,
+  },
   props: { closed: Boolean },
   data: () => ({
     walletUrl: process.env.VUE_APP_WALLET_URL,
@@ -61,7 +70,7 @@ export default {
       },
     }),
   },
-  methods: mapMutations(['updateCurrency']),
+  methods: mapMutations(['updateCurrency', 'enableIframeWallet']),
 };
 </script>
 

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -48,7 +48,7 @@ export default {
   useSdkWallet(state) {
     state.useSdkWallet = true;
   },
-  useIframeWallet(state) {
+  enableIframeWallet(state) {
     state.useIframeWallet = true;
   },
   setUserProfile(state, profile) {

--- a/src/utils/aeternity.js
+++ b/src/utils/aeternity.js
@@ -70,7 +70,7 @@ export const scanForWallets = async () => {
     connectionInfo: { id: 'spy' },
   });
   const detector = await Detector({ connection: scannerConnection });
-  const webWalletTimeout = setTimeout(() => !IS_MOBILE_DEVICE && store.commit('useIframeWallet'), 2000);
+  const webWalletTimeout = setTimeout(() => !IS_MOBILE_DEVICE && store.commit('enableIframeWallet'), 10000);
 
   return new Promise((resolve) => {
     detector.scan(async ({ newWallet }) => {


### PR DESCRIPTION
original issue: on #810 web wallet sometimes is opening even if the extension is installed

The increasing of timeout helps in that case, so probably app initialization takes a bit longer on that branch. But initialization time also depends on the hardware and network conditions so, as in https://github.com/aeternity/superhero-wallet/pull/540, I'm proposing to don't depend on timeouts.

In particular, I think we should increase the timeout so some upper bound (10 seconds instead of 2?) and to allow the user to open the web wallet manually if he wants to use it. Until we find a way to use the extension and the web wallet simultaneously (https://github.com/aeternity/superhero-ui/issues/606).

<img width="385" alt="Screenshot 2020-10-09 at 08 53 29" src="https://user-images.githubusercontent.com/9007851/95548038-eef74580-0a0c-11eb-9b96-b9144734e2fb.png">
