### PR TITLE
Refactor TipTitle component

### DIFF
--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -27,15 +27,7 @@
           </ThreeDotsMenu>
         </AuthorAndDate>
       </div>
-      <div
-        class="tip__note pr-2"
-        @click.stop
-      >
-        <TipTitle
-          :tip="tip"
-          :go-to-tip="goToTip"
-        />
-      </div>
+      <TipTitle :tip-title="tip.title" />
       <div
         v-if="isPreviewToBeVisualized(tip)"
         class="tip__article"
@@ -249,7 +241,7 @@ export default {
     }
   }
 
-  .tip__note {
+  .tip-title {
     @include truncate-overflow-mx(4);
 
     color: $tip_note_color;
@@ -257,14 +249,7 @@ export default {
     line-height: 1.1rem;
     margin-bottom: 0.8rem;
     padding-left: 1rem;
-
-    ::v-deep .title .topic {
-      color: $standard_font_color;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
+    padding-right: 0.5rem;
   }
 
   .retip__icon {
@@ -453,14 +438,14 @@ export default {
       right: -50%;
     }
 
-    .tip__note,
+    .tip-title,
     .tip__article .tip__article__content {
       font-size: 0.75rem;
     }
   }
 
   @media only screen and (max-width: 600px) {
-    .tip__note {
+    .tip-title {
       font-size: 0.75rem;
     }
 
@@ -517,7 +502,7 @@ export default {
       }
     }
 
-    .tip__note {
+    .tip-title {
       padding: 0;
     }
 

--- a/src/components/tipRecords/TipTitle.vue
+++ b/src/components/tipRecords/TipTitle.vue
@@ -1,21 +1,16 @@
 <template>
-  <div>
-    <div
-      v-for="(part, id) in splitByTopics"
-      :key="id"
-      class="title"
-    >
+  <div class="tip-title">
+    <template v-for="(part, id) in splitByTopics">
       <Topic
         v-if="part.matches"
+        :key="id"
         :topic="part.text"
+        @click.native.stop
       />
-      <span
-        v-else
-        @click="goToTip(tip.id)"
-      >
+      <template v-else>
         {{ part.text }}
-      </span>
-    </div>
+      </template>
+    </template>
   </div>
 </template>
 
@@ -26,30 +21,15 @@ import Topic from './Topic.vue';
 export default {
   components: { Topic },
   props: {
-    tip: { type: Object, required: true },
-    goToTip: { type: Function, required: true },
+    tipTitle: { type: String, required: true },
   },
   computed: {
     splitByTopics() {
-      return this.tip.title.split(topicsRegex).map((part) => {
-        const matches = topicsRegex.test(part);
-
-        return {
-          text: part,
-          matches,
-        };
-      });
+      return this.tipTitle.split(topicsRegex).map((text) => ({
+        text,
+        matches: topicsRegex.test(text),
+      }));
     },
   },
 };
 </script>
-
-<style lang="scss" scoped>
-  .title {
-    display: inline;
-
-    .topiclink {
-      color: $custom_links_color;
-    }
-  }
-</style>

--- a/src/components/tipRecords/Topic.vue
+++ b/src/components/tipRecords/Topic.vue
@@ -3,7 +3,7 @@
     class="topic"
     :to="{ name: 'tips-search', params: { query: topic } }"
   >
-    {{ topic }}
+    <template>{{ topic }}</template>
   </RouterLink>
 </template>
 
@@ -16,11 +16,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .topic {
-    color: $custom_links_color;
+.topic {
+  color: $standard_font_color;
 
-    &:hover {
-      cursor: pointer;
-    }
+  &:hover {
+    text-decoration: underline;
   }
+}
 </style>


### PR DESCRIPTION
I'm proposing to use the same styles to show topics in Tips and in the sidebar:

<img width="787" alt="Screenshot 2020-10-15 at 07 56 24" src="https://user-images.githubusercontent.com/9007851/96078905-2efe7280-0ebc-11eb-80d2-dfb73ca712be.png">

Also, fixes in Topic component enables more accurate rendering:
| Before | After |
|---|---|
| <img width="366" alt="Screenshot 2020-10-15 at 07 55 43" src="https://user-images.githubusercontent.com/9007851/96078963-4e959b00-0ebc-11eb-8057-42b6c3d59ea4.png"> | <img width="366" alt="Screenshot 2020-10-15 at 07 55 29" src="https://user-images.githubusercontent.com/9007851/96078968-4fc6c800-0ebc-11eb-87a8-3b7f95ad0858.png"> |
