### PR TITLE
Missing preview fix

### DIFF
--- a/src/components/tipRecords/TipPreview.vue
+++ b/src/components/tipRecords/TipPreview.vue
@@ -3,7 +3,7 @@
     class="tip__article"
   >
     <div
-      v-if="richPreviewComponent"
+      v-if="richPreviewComponent && isPreviewToBeVisualized"
       class="tip__article--hasresults"
     >
       <div class="tip__article__content">


### PR DESCRIPTION
Fixes #885 

If the preview is not generated yet the proper "No preview available" view is shown
Before:
<img src="https://user-images.githubusercontent.com/47859124/99777950-b4a8ba00-2b1b-11eb-8b51-7bb51711c367.png" width=600>
After:
<img src="https://user-images.githubusercontent.com/47859124/99778003-c7bb8a00-2b1b-11eb-9f7f-904204113549.png" width=600>

