### PR TITLE
Extract text from Venture logo

### DIFF
--- a/src/assets/iconVenture.svg
+++ b/src/assets/iconVenture.svg
@@ -1,6 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="109" height="15" viewBox="0 0 109 15">
-  <g id="Brand_Venture" data-name="Brand/Venture" transform="translate(0 2)">
-    <path id="Shape" d="M8.5,10h0L0,0H6.3L8.5,2.658,10.7,0H17L8.5,10ZM1.063.56,8.5,9.23l2.479-2.937L9.067,4.056,11.334,1.4h2.621L10.767,5.245l.567.7L15.937.49H10.979l-4.321,5.1L3.046,1.4H5.6L7.579,3.776l.567-.7L6.021.56ZM11.616,1.888,9.775,4.056l.637.769,2.479-2.937Zm-7.508,0L6.587,4.825l.638-.7L5.383,1.888H4.109ZM8.5,7.832h0L7.225,6.294,8.5,4.825,9.775,6.294,8.5,7.831Zm0-2.237-.637.7.637.77.638-.77Z" transform="translate(0 1)" fill="#cda564"/>
-    <text id="Branded_by_Venture" data-name="Branded by Venture" transform="translate(21 10)" fill="#cda564" font-size="11" font-family="Roboto-Regular, Roboto" letter-spacing="-0.045em"><tspan x="0" y="0">Branded by Venture</tspan></text>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 10">
+  <path d="M8.5,10h0L0,0H6.3L8.5,2.658,10.7,0H17L8.5,10ZM1.063.56,8.5,9.23l2.479-2.937L9.067,4.056,11.334,1.4h2.621L10.767,5.245l.567.7L15.937.49H10.979l-4.321,5.1L3.046,1.4H5.6L7.579,3.776l.567-.7L6.021.56ZM11.616,1.888,9.775,4.056l.637.769,2.479-2.937Zm-7.508,0L6.587,4.825l.638-.7L5.383,1.888H4.109ZM8.5,7.832h0L7.225,6.294,8.5,4.825,9.775,6.294,8.5,7.831Zm0-2.237-.637.7.637.77.638-.77Z" fill="currentColor"/>
 </svg>

--- a/src/components/layout/FooterSection.vue
+++ b/src/components/layout/FooterSection.vue
@@ -51,7 +51,8 @@
         target="_blank"
         href="https://venture.com/"
       >
-        <img src="../../assets/iconVenture.svg">
+        <!--eslint-disable-next-line vue-i18n/no-raw-text-->
+        <IconVenture /> <span>Branded by Venture</span>
       </a>
     </div>
     <div
@@ -69,10 +70,11 @@
 import { mapGetters } from 'vuex';
 import { createDeepLinkUrl } from '../../utils';
 import OutlinedButton from '../OutlinedButton.vue';
+import IconVenture from '../../assets/iconVenture.svg?icon-component';
 
 export default {
   components: {
-    OutlinedButton,
+    OutlinedButton, IconVenture,
   },
   data: () => ({
     version: process.env.npm_package_version,
@@ -101,9 +103,16 @@ export default {
 
     .venture {
       margin-left: 0.35rem;
+      color: #cda564;
+      letter-spacing: -0.045em;
 
-      img {
-        height: 0.65rem;
+      svg {
+        height: 0.5rem;
+      }
+
+      svg,
+      span {
+        vertical-align: middle;
       }
 
       &:hover {


### PR DESCRIPTION
While #894 I have noticed that that logo's font is broken. According to SVG, the font should be Roboto, 11px. It is the same as the near text, so I assumed that is should be fine to extract "Branded by Venture" as text ant to put it near their logo.

Before:

<img width="619" alt="Screenshot 2020-11-25 at 07 05 05" src="https://user-images.githubusercontent.com/9007851/100182306-5863e280-2eed-11eb-9b76-77ead1c227dc.png">

After:

<img width="619" alt="Screenshot 2020-11-25 at 07 05 09" src="https://user-images.githubusercontent.com/9007851/100182315-5c900000-2eed-11eb-88fa-5ae64a80c7a6.png">
