### PR TITLE
Hotfix/hide statistics and rename main to feed

### DIFF
--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -268,7 +268,7 @@ export default {
     ...mapState('aeternity', ['sdk']),
     ...mapState({ currentAddress: 'address' }),
     userChainName() {
-      return this.chainNames[this.address];
+      return this.profile.preferredChainName;
     },
     hasCreationDate() {
       return this.profile.createdAt.length > 0;

--- a/src/components/layout/LeftSection.vue
+++ b/src/components/layout/LeftSection.vue
@@ -1,17 +1,14 @@
 <template>
   <div class="left-section">
     <Navigation />
-    <Overview />
   </div>
 </template>
 
 <script>
 import Navigation from './Navigation.vue';
-import Overview from './Overview.vue';
 
 export default {
   components: {
-    Overview,
     Navigation,
   },
 };

--- a/src/components/tipRecords/AuthorAndDate.vue
+++ b/src/components/tipRecords/AuthorAndDate.vue
@@ -43,7 +43,7 @@
 
 <script>
 import { debounce } from 'lodash-es';
-import { mapState } from 'vuex';
+import Backend from '../../utils/backend';
 import FormatDate from './FormatDate.vue';
 import Avatar from '../Avatar.vue';
 import UserCard from '../UserCard.vue';
@@ -57,7 +57,7 @@ export default {
   props: {
     address: { type: String, required: true },
   },
-  data: () => ({ hover: false }),
+  data: () => ({ hover: false, name: null }),
   computed: {
     hoverDebounced: {
       get() {
@@ -67,11 +67,10 @@ export default {
         this.hover = hover;
       }, 500),
     },
-    ...mapState({
-      name({ chainNames }) {
-        return chainNames[this.address] || '';
-      },
-    }),
+  },
+  async mounted() {
+    const { preferredChainName } = await Backend.getProfile(this.address);
+    this.name = preferredChainName;
   },
 };
 </script>

--- a/src/components/tipRecords/TipMedia.vue
+++ b/src/components/tipRecords/TipMedia.vue
@@ -47,6 +47,7 @@ export default {
   width: 100%;
   max-width: 100%;
   border-radius: 0.5rem;
+  height: 0;
 
   .media-container {
     max-width: 100%;
@@ -60,23 +61,23 @@ export default {
     display: grid;
 
     &.template1 {
-      grid-template-areas: 'pos0';
+      grid-template: 'pos0' 100%;
     }
 
     &.template2 {
-      grid-template-areas: 'pos0 pos1';
+      grid-template: 'pos0 pos1' 100%;
     }
 
     &.template3 {
-      grid-template-areas:
-        'pos0 pos1'
-        'pos0 pos2';
+      grid-template:
+        'pos0 pos1' 50%
+        'pos0 pos2' 50%;
     }
 
     &.template4 {
-      grid-template-areas:
-        'pos0 pos0 pos1 pos1'
-        'pos0 pos0 pos2 pos3';
+      grid-template:
+        'pos0 pos0 pos1 pos1' 50%
+        'pos0 pos0 pos2 pos3' 50%;
     }
 
     img {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,7 +15,8 @@
   "aeternityBlockchain": "aeternity blockchain",
   "views": {
     "FeedList": {
-      "main": "Main",
+      "main": "Feed",
+      "tips": "Tips",
       "posts": "Posts"
     },
     "CreateProfile": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -11,6 +11,11 @@
   "FAQ": "Preguntas frecuentes",
   "FellowSuperhero": "Querido Superhero",
   "views": {
+    "FeedList": {
+      "main": "Feed",
+      "tips": "Tips",
+      "posts": "Posts"
+    },
     "CreateProfile": {
       "header1": "CÓMO USAR SUPERHERO.COM",
       "header2": "Plataforma social sin una agenda oculta.",
@@ -494,15 +499,8 @@
       "Initiate": "Initiate Vote",
       "Spread": "Accumulated Spread",
       "Stake": "Majority Stake",
-      "RibbonTabs": [
-        "Token Info",
-        "Funds release vote"
-      ],
-      "Tabs": [
-        "Ongoing Votes",
-        "Past Votes",
-        "My Votes"
-      ]
+      "RibbonTabs": ["Token Info", "Funds release vote"],
+      "Tabs": ["Ongoing Votes", "Past Votes", "My Votes"]
     },
     "WordBazaar": {
       "Title": "WordBazaar",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -14,6 +14,11 @@
   "Balance": "Balance:",
   "aeternityBlockchain": "aeternity blockchain",
   "views": {
+    "FeedList": {
+      "main": "Feed",
+      "tips": "Tips",
+      "posts": "Posts"
+    },
     "CreateProfile": {
       "header1": "COMMENT UTILISER SUPERHERO.COM",
       "header2": "Plateforme sociale qui respecte votre liberté d'expression.",
@@ -486,15 +491,8 @@
       "Initiate": "Initiate Vote",
       "Spread": "Accumulated Spread",
       "Stake": "Majority Stake",
-      "RibbonTabs": [
-        "Token Info",
-        "Funds release vote"
-      ],
-      "Tabs": [
-        "Ongoing Votes",
-        "Past Votes",
-        "My Votes"
-      ]
+      "RibbonTabs": ["Token Info", "Funds release vote"],
+      "Tabs": ["Ongoing Votes", "Past Votes", "My Votes"]
     },
     "WordBazaar": {
       "Title": "WordBazaar",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -12,6 +12,11 @@
   "FellowSuperhero": "超级英雄",
   "aeternityBlockchain": "AEternity区块链",
   "views": {
+    "FeedList": {
+      "main": "Feed",
+      "tips": "Tips",
+      "posts": "Posts"
+    },
     "CreateProfile": {
       "header1": "如何使用 SUPERHERO.COM",
       "header2": "没有隐藏协议的社交平台.",
@@ -383,15 +388,8 @@
       "Initiate": "Initiate Vote",
       "Spread": "Accumulated Spread",
       "Stake": "Majority Stake",
-      "RibbonTabs": [
-        "Token Info",
-        "Funds release vote"
-      ],
-      "Tabs": [
-        "Ongoing Votes",
-        "Past Votes",
-        "My Votes"
-      ]
+      "RibbonTabs": ["Token Info", "Funds release vote"],
+      "Tabs": ["Ongoing Votes", "Past Votes", "My Votes"]
     },
     "WordBazaar": {
       "Title": "WordBazaar",

--- a/src/views/FeedList.vue
+++ b/src/views/FeedList.vue
@@ -18,7 +18,7 @@
         >
           <IconDiamond />
           <span>
-            {{ $t('tips') }}
+            {{ $t('views.FeedList.tips')}}
           </span>
         </FilterButton>
         <FilterButton

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import Backend from '../utils/backend';
 import backendAuthMixin from '../utils/backendAuthMixin';
 import ListOfTipsAndComments from '../components/ListOfTipsAndComments.vue';
 import BackButtonRibbon from '../components/BackButtonRibbon.vue';
@@ -26,11 +26,11 @@ export default {
   props: {
     address: { type: String, required: true },
   },
-  computed: mapState({
-    name({ chainNames }) {
-      return chainNames[this.address] || this.$t('FellowSuperhero');
-    },
-  }),
+  data: () => ({ hover: false, name: null }),
+  async mounted() {
+    const { preferredChainName } = await Backend.getProfile(this.address);
+    this.name = preferredChainName || this.$t('FellowSuperhero');
+  },
   metaInfo() {
     return { title: this.name };
   },


### PR DESCRIPTION
- Tip statistics from left column are removed
- Feed tabs renamed "Main, Feed, Posts" -> "Feed, Tips, Posts"
- Fixed visual bug when there are multiple images in post
- Show preferred chain name of user profile (if any) and 'Fellow Superhero' if none 

Before:
<img src="https://user-images.githubusercontent.com/47859124/114412347-ae43d900-9bb5-11eb-90f6-b16e2a4be274.png" width="400px">

After:
<img src="https://user-images.githubusercontent.com/47859124/114412523-d9c6c380-9bb5-11eb-8a69-9aac6c7642a7.png" width="400px">
