### PR TITLE
Change deeplink tip url

### DIFF
--- a/src/components/TipInput.vue
+++ b/src/components/TipInput.vue
@@ -165,7 +165,7 @@ export default {
       return createDeepLinkUrl(
         this.tip
           ? { type: 'retip', id: this.tip.id }
-          : { type: 'tip', url: this.tipUrl },
+          : { type: 'tips', url: this.tipUrl },
       );
     },
     isValid() {

--- a/src/components/layout/MobileNavigation.vue
+++ b/src/components/layout/MobileNavigation.vue
@@ -74,7 +74,7 @@ export default {
   data: () => ({
     showOverlay: false,
     showSearchFeed: false,
-    tipDeepLink: createDeepLinkUrl({ type: 'tip' }),
+    tipDeepLink: createDeepLinkUrl({ type: 'tips' }),
   }),
   computed: {
     ...mapState('aeternity', ['useSdkWallet']),

--- a/src/components/layout/sendTip/SendTip.vue
+++ b/src/components/layout/sendTip/SendTip.vue
@@ -157,7 +157,7 @@ export default {
       this.clearTipForm();
     },
     openTipDeeplink() {
-      window.location = createDeepLinkUrl({ type: 'tip' });
+      window.location = createDeepLinkUrl({ type: 'tips' });
     },
   },
 };


### PR DESCRIPTION
After new wallet release `/tip` path will change to `/tips` and this deeplinks will break.