### PR TITLE
Adjust half-closed wallet height

### DIFF
--- a/src/components/layout/RightSectionWallet.vue
+++ b/src/components/layout/RightSectionWallet.vue
@@ -179,7 +179,7 @@ export default {
     transition: height 0.25s;
 
     &.half-closed {
-      height: 190px;
+      height: 245px;
     }
   }
 


### PR DESCRIPTION
Fixes #1089

<div style="display:flex">
<img width="345" alt="Screenshot 2021-06-25 at 15 29 45" src="https://user-images.githubusercontent.com/47859124/123424982-34bf6280-d5ca-11eb-8b6c-a68fe2a7e5e2.png">
--->
<img width="345" alt="Screenshot 2021-06-25 at 15 30 06" src="https://user-images.githubusercontent.com/47859124/123425034-43a61500-d5ca-11eb-974f-4875daa80ea8.png">
</div>
