### PR TITLE
fix(AeAmountFiat): remove extra space between ae and fiat

### DIFF
--- a/src/components/AeAmountFiat.vue
+++ b/src/components/AeAmountFiat.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="ae-amount-fiat">
     <AeAmount v-bind="$attrs" />
-    &nbsp;<FiatValue v-bind="$attrs" />
+    {{ ' ' }}<FiatValue v-bind="$attrs" />
   </span>
 </template>
 


### PR DESCRIPTION
Before:
![Screenshot 2021-07-06 at 13 37 38](https://user-images.githubusercontent.com/9007851/124586623-54bf1380-de5f-11eb-9989-da4a1cf484b1.png)
In debugger:
![Screenshot 2021-07-06 at 13 38 47](https://user-images.githubusercontent.com/9007851/124586739-7fa96780-de5f-11eb-8185-31f5880b3f9e.png)
After:
![Screenshot 2021-07-06 at 13 37 23](https://user-images.githubusercontent.com/9007851/124586600-4e309c00-de5f-11eb-830e-360d994300e5.png)

somehow it works correctly in the latest release 🤔 