### PR TITLE
refactor(backend): throw exception instead of returning null

### DIFF
--- a/src/components/FeedItemMenu.vue
+++ b/src/components/FeedItemMenu.vue
@@ -86,12 +86,13 @@ export default {
           body: this.$t('components.tipRecords.TipRecord.claimBodySuccess'),
         });
         this.resolve();
-      } catch (e) {
+      } catch (error) {
         await this.$store.dispatch('modals/open', {
           name: 'failure',
           title: this.$t('components.tipRecords.TipRecord.claimTitle'),
           body: this.$t('components.tipRecords.TipRecord.claimBodyFailure'),
         });
+        console.error(error);
       }
     },
     async pinOrUnPinTip() {

--- a/src/components/SendComment.vue
+++ b/src/components/SendComment.vue
@@ -15,7 +15,6 @@
 </template>
 
 <script>
-import { handleUnknownError } from '../utils';
 import MessageInput from './MessageInput.vue';
 
 export default {
@@ -43,8 +42,8 @@ export default {
           { text: this.comment, tipId: this.tipId, parentId: this.parentId },
         );
         this.comment = '';
-      } catch (e) {
-        if (e.message !== 'Operation rejected by user') handleUnknownError(e);
+      } catch (error) {
+        if (error.message !== 'Operation rejected by user') throw error;
       } finally {
         this.loading = false;
       }

--- a/src/components/TipInputPopup.vue
+++ b/src/components/TipInputPopup.vue
@@ -130,7 +130,7 @@ export default {
         this.resolve(true);
       } catch (error) {
         this.error = true;
-        throw error;
+        console.error(error);
       } finally {
         this.showLoading = false;
       }

--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="user-info">
+  <Spinner
+    v-if="!profile"
+    class="user-info"
+  />
+  <div
+    v-else
+    class="user-info"
+  >
     <div
       class="profile-section"
       :style="profile.coverImage
@@ -7,13 +14,13 @@
     >
       <div
         class="profile-header"
-        :class="{ 'profile-editable': backendAuth && currentAddress === address }"
+        :class="{ 'profile-editable': backendAuth && isOwn }"
       >
         <ClientOnly>
           <div class="profile-image">
             <Avatar :address="address" />
             <TipInput
-              v-if="currentAddress !== address"
+              v-if="!isOwn"
               :user-address="address"
               class="profile-button avatar-button"
             />
@@ -47,7 +54,7 @@
             :href="explorerTransactionsUrl"
           >
             <div class="chain">
-              {{ userChainName ? userChainName : $t('FellowSuperhero') }}
+              {{ profile.preferredChainName || $t('FellowSuperhero') }}
             </div>
             <div class="text-ellipsis">{{ address }}</div>
           </a>
@@ -63,7 +70,7 @@
             <ClientOnly>
               <div class="location">
                 <img
-                  v-if="profile.location.length || currentAddress === address"
+                  v-if="profile.location.length || isOwn"
                   src="../assets/location.svg"
                 >
                 <input
@@ -73,17 +80,13 @@
                   type="text"
                   :placeholder="$t('views.UserProfileView.LocationPlaceholder')"
                 >
-                <span v-if="!editMode && (profile.location.length || currentAddress === address)">
-                  {{
-                    profile.location.length
-                      ? profile.location
-                      : $t('views.UserProfileView.Location')
-                  }}
+                <span v-if="!editMode && (profile.location || isOwn)">
+                  {{ profile.location || $t('views.UserProfileView.Location') }}
                 </span>
               </div>
             </ClientOnly>
             <div
-              v-if="userStats && hasCreationDate"
+              v-if="profile.createdAt"
               class="joined"
             >
               <span>{{ $t('views.UserProfileView.Joined') }}</span>
@@ -93,7 +96,7 @@
         </div>
         <ClientOnly>
           <div
-            v-if="backendAuth && currentAddress === address"
+            v-if="backendAuth && isOwn"
             class="edit-buttons"
           >
             <label
@@ -186,7 +189,10 @@
         </div>
       </div>
     </div>
-    <div class="profile-stats">
+    <div
+      v-if="userStats"
+      class="profile-stats"
+    >
       <div
         v-for="(divClass, index) in ['tip_stats', 'stats']"
         :key="index"
@@ -222,6 +228,7 @@
 import { mapState, mapActions } from 'vuex';
 import ClientOnly from 'vue-client-only';
 import Backend from '../utils/backend';
+import Spinner from './Loader.vue';
 import AeAmountFiat from './AeAmountFiat.vue';
 import Avatar from './Avatar.vue';
 import { EventBus } from '../utils/eventBus';
@@ -234,6 +241,7 @@ import IconCancel from '../assets/iconCancel.svg?icon-component';
 export default {
   components: {
     ClientOnly,
+    Spinner,
     AeAmountFiat,
     Avatar,
     TipInput,
@@ -248,23 +256,9 @@ export default {
   data() {
     return {
       maxLength: 250,
-      userStats: {
-        tipsLength: '-',
-        retipsLength: '-',
-        totalTipAmount: '0',
-        claimedUrlsLength: '-',
-        unclaimedAmount: '0',
-        claimedAmount: '0',
-        userComments: '-',
-      },
+      userStats: null,
       editMode: false,
-      userCommentCount: 0,
-      profile: {
-        biography: '',
-        createdAt: '',
-        location: '',
-        coverImage: '',
-      },
+      profile: null,
       balance: '',
       BACKEND_URL: process.env.VUE_APP_BACKEND_URL,
     };
@@ -272,13 +266,11 @@ export default {
   computed: {
     ...mapState(['cookiesConsent', 'chainNames']),
     ...mapState('aeternity', ['sdk']),
-    ...mapState({ currentAddress: 'address' }),
-    userChainName() {
-      return this.profile.preferredChainName;
-    },
-    hasCreationDate() {
-      return this.profile.createdAt.length > 0;
-    },
+    ...mapState({
+      isOwn({ address }) {
+        return this.address === address;
+      },
+    }),
     joinedAtISO() {
       try {
         return new Date(this.profile.createdAt).toISOString();
@@ -302,28 +294,25 @@ export default {
       return `${this.profile.biography.length}/${this.maxLength}`;
     },
     tipStats() {
-      return [
-        {
-          value: this.userStats.totalTipsLength,
-          title: this.$t('views.UserProfileView.TipsSent'),
-          amount: this.userStats.totalAmount,
-        },
-        {
-          value: this.userStats.urlStats?.totaltipslength,
-          title: this.$t('views.UserProfileView.TipsReceived'),
-          amount: this.userStats.urlStats?.totalAmount,
-        },
-      ];
+      return [{
+        value: this.userStats.totalTipsLength ?? 0,
+        title: this.$t('views.UserProfileView.TipsSent'),
+        amount: this.userStats.totalamount ?? '0',
+      }, {
+        value: this.userStats.urlStats.totalTipsLength,
+        title: this.$t('views.UserProfileView.TipsReceived'),
+        amount: this.userStats.urlStats.totalAmount,
+      }];
     },
     showedStats() {
-      return [
-        { value: this.userStats.commentCount, title: this.$t('views.UserProfileView.Comments') },
-        {
-          value: this.userStats.claimedUrlsLength,
-          image: SuccessIcon,
-          title: this.$t('views.UserProfileView.ClaimedUrls'),
-        },
-      ];
+      return [{
+        value: this.userStats.commentCount,
+        title: this.$t('views.UserProfileView.Comments'),
+      }, {
+        value: this.userStats.claimedUrlsLength,
+        image: SuccessIcon,
+        title: this.$t('views.UserProfileView.ClaimedUrls'),
+      }];
     },
     explorerTransactionsUrl() {
       return `${process.env.VUE_APP_EXPLORER_URL}/account/transactions/${this.address}`;
@@ -335,10 +324,8 @@ export default {
   mounted() {
     this.$watch(
       () => this.address,
-      () => {
-        this.reloadData();
-        this.reloadBalance();
-      },
+      () => this.reloadData(),
+      { immediate: true },
     );
     this.reloadBalance();
 
@@ -351,13 +338,6 @@ export default {
   },
   methods: {
     ...mapActions('backend', ['setCookies']),
-    async reloadBalance() {
-      await this.$watchUntilTruly(() => this.sdk);
-      this.balance = await this.sdk.balance(this.address).catch((error) => {
-        if (error.status !== 404) throw error;
-        return 0;
-      });
-    },
     async resetEditedValues() {
       this.editMode = false;
       await this.reloadProfile();
@@ -385,16 +365,19 @@ export default {
         Backend.getSenderStats(this.address).then((stats) => {
           this.userStats = stats;
         }),
+        (async () => {
+          await this.$watchUntilTruly(() => this.sdk);
+          this.balance = await this.sdk.balance(this.address).catch((error) => {
+            if (error.status !== 404) throw error;
+            return 0;
+          });
+        })(),
       ]);
     },
     async reloadProfile() {
-      this.profile = {
-        location: '',
-        biography: '',
-        coverImage: '',
-        ...await Backend.getProfile(this.address),
-      };
-      if (this.address === this.currentAddress) this.$store.commit('setUserProfile', this.profile);
+      this.profile = await Backend.getProfile(this.address);
+      this.profile.biography = this.profile.biography || '';
+      if (this.isOwn) this.$store.commit('setUserProfile', this.profile);
     },
   },
 };

--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -274,7 +274,7 @@ export default {
     joinedAtISO() {
       try {
         return new Date(this.profile.createdAt).toISOString();
-      } catch (e) {
+      } catch {
         return '';
       }
     },
@@ -286,7 +286,7 @@ export default {
             month: 'long',
             day: 'numeric',
           });
-      } catch (e) {
+      } catch {
         return '';
       }
     },

--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -2,7 +2,8 @@
   <div class="user-info">
     <div
       class="profile-section"
-      :style="{ '--cover-image': 'url(' + BACKEND_URL + profile.coverImage + ')' }"
+      :style="profile.coverImage
+        ? { '--cover-image': 'url(' + BACKEND_URL + profile.coverImage + ')' } : {}"
     >
       <div
         class="profile-header"
@@ -633,8 +634,7 @@ input[type="file"] {
 .profile-section {
   background:
     linear-gradient(rgba($light_color, 0.8), rgba($light_color, 0.8)),
-    var(--cover-image),
-    $light_color;
+    var(--cover-image, $light_color);
   background-size: cover;
   background-position: center;
   position: relative;

--- a/src/components/layout/sendTip/GiphySearch.vue
+++ b/src/components/layout/sendTip/GiphySearch.vue
@@ -38,6 +38,7 @@
 </template>
 
 <script>
+import { fetchJson } from '../../../utils';
 import Loading from '../../Loading.vue';
 import SearchInput from '../SearchInput.vue';
 
@@ -68,8 +69,12 @@ export default {
     },
     async search() {
       try {
-        const results = await fetch(`https://api.giphy.com/v1/gifs/${this.query ? `search?q=${this.query}&` : 'trending?'}api_key=${process.env.VUE_APP_GIPHY_API_KEY}&limit=10&offset=${this.offset}`);
-        const { data, pagination } = await results.json();
+        const url = new URL(`https://api.giphy.com/v1/gifs/${this.query ? 'search' : 'trending'}`);
+        if (this.query) url.searchParams.set('q', this.query);
+        url.searchParams.set('limit', 10);
+        url.searchParams.set('offset', this.offset);
+        url.searchParams.set('api_key', process.env.VUE_APP_GIPHY_API_KEY);
+        const { data, pagination } = await fetchJson(url);
         this.resultsCount = `${pagination.total_count.toLocaleString()} Results`;
         this.results.push(...data.map(({ images }) => ({
           still: images.fixed_width_still.url,

--- a/src/components/layout/sendTip/SendPost.vue
+++ b/src/components/layout/sendTip/SendPost.vue
@@ -60,6 +60,7 @@
 
 <script>
 import { mapState } from 'vuex';
+import { fetchJson } from '../../../utils';
 import { EventBus } from '../../../utils/eventBus';
 import Backend from '../../../utils/backend';
 import MessageInput from '../../MessageInput.vue';
@@ -149,14 +150,13 @@ export default {
       const formData = new FormData();
       formData.append('image', event.target.files[0]);
       try {
-        const result = await fetch('https://api.imgur.com/3/image.json', {
+        const { data } = await fetchJson('https://api.imgur.com/3/image.json', {
           method: 'post',
           body: formData,
           headers: {
             Authorization: `Client-ID ${process.env.VUE_APP_IMGUR_API_CLIENT_ID}`,
           },
         });
-        const { data } = await result.json();
         this.media.push({ link: data.link, deletehash: data.deletehash });
       } finally { this.uploadingMedia = false; }
     },

--- a/src/components/layout/sendTip/SendTip.vue
+++ b/src/components/layout/sendTip/SendTip.vue
@@ -130,9 +130,6 @@ export default {
         });
         EventBus.$emit('reloadData');
       } catch (error) {
-        if (error.code && error.code === 4) {
-          return;
-        }
         console.error(error);
         this.$store.dispatch('modals/open', {
           name: 'failure',

--- a/src/components/layout/sendTip/SendTip.vue
+++ b/src/components/layout/sendTip/SendTip.vue
@@ -115,12 +115,13 @@ export default {
       const amount = shiftDecimalPlaces(this.sendTipForm.amount,
         this.inputToken !== null ? this.tokenInfo[this.inputToken].decimals : 18).toFixed();
 
-      this.$store.dispatch('aeternity/tip', {
-        url: this.sendTipForm.url,
-        title: this.sendTipForm.title,
-        amount,
-        tokenAddress: this.inputToken,
-      }).then(async () => {
+      try {
+        await this.$store.dispatch('aeternity/tip', {
+          url: this.sendTipForm.url,
+          title: this.sendTipForm.title,
+          amount,
+          tokenAddress: this.inputToken,
+        });
         this.clearTipForm();
         this.$store.dispatch('modals/open', {
           name: 'success',
@@ -128,18 +129,19 @@ export default {
           body: this.$t('components.layout.SendTip.SuccessText'),
         });
         EventBus.$emit('reloadData');
-      }).catch((e) => {
-        this.sendingTip = false;
-        if (e.code && e.code === 4) {
+      } catch (error) {
+        if (error.code && error.code === 4) {
           return;
         }
-        console.error(e);
+        console.error(error);
         this.$store.dispatch('modals/open', {
           name: 'failure',
           title: this.$t('components.layout.SendTip.ErrorHeader'),
           body: this.$t('components.layout.SendTip.ErrorText'),
         });
-      });
+      } finally {
+        this.sendingTip = false;
+      }
     },
     clearTipForm() {
       this.sendTipForm = { amount: 0, url: '', title: '' };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,7 +10,7 @@ import modals from './plugins/modals';
 import backend from './modules/backend';
 import aeternity from './modules/aeternity';
 import Backend from '../utils/backend';
-import { handleUnknownError } from '../utils';
+import { handleUnknownError, fetchJson } from '../utils';
 
 Vue.use(Vuex);
 
@@ -75,8 +75,7 @@ export default () => new Vuex.Store({
     },
     async initMiddleware({ commit }) {
       const specUrl = `${process.env.VUE_APP_MIDDLEWARE_URL}/swagger/swagger.json`;
-      const res = await fetch(specUrl);
-      const spec = await res.json();
+      const spec = await fetchJson(specUrl);
 
       spec.paths = {
         ...spec.paths,

--- a/src/store/modules/aeternity.js
+++ b/src/store/modules/aeternity.js
@@ -341,7 +341,9 @@ export default {
       }
 
       await contractV1.methods.tip(url, title, { amount });
-      return dispatch('backend/awaitTip', null, { root: true });
+      return dispatch('backend/awaitTip', null, { root: true })
+        // TODO: remove after solving https://github.com/aeternity/tipping-community-backend/issues/371
+        .catch(console.error);
     },
     async retip({
       dispatch,
@@ -368,7 +370,9 @@ export default {
 
       if (contractAddress === process.env.VUE_APP_CONTRACT_V1_ADDRESS) {
         await contractV1.methods.retip(Number(id.split('_')[0]), { amount });
-        return dispatch('backend/awaitRetip', null, { root: true });
+        return dispatch('backend/awaitRetip', null, { root: true })
+          // TODO: remove after solving https://github.com/aeternity/tipping-community-backend/issues/371
+          .catch(console.error);
       }
 
       if (contractAddress === process.env.VUE_APP_CONTRACT_V2_ADDRESS) {

--- a/src/store/modules/backend.js
+++ b/src/store/modules/backend.js
@@ -86,8 +86,6 @@ export default {
         Backend.getTipById(id),
         Backend.getTipComments(id),
       ]);
-      // TODO: Remove after backend methods start to throw exceptions on not found
-      if (!tip) throw new Error(`Can't find tip with id: ${id}`);
       commit('setTip', {
         id,
         value: {
@@ -101,8 +99,6 @@ export default {
     },
     async reloadComment({ commit }, id) {
       const value = await Backend.getCommentById(id);
-      // TODO: Remove after backend methods start to throw exceptions on not found
-      if (!value) throw new Error(`Can't find comment with id: ${id}`);
       commit('setComment', { id, value });
     },
     async awaitTip(_, id) {
@@ -119,7 +115,7 @@ export default {
       commit('setStats', { ...stats, height });
     },
     async reloadPrices({ commit }) {
-      commit('setPrices', (await Backend.getPrice())?.aeternity);
+      commit('setPrices', (await Backend.getPrice()).aeternity);
     },
     // eslint-disable-next-line consistent-return
     async callWithAuth({

--- a/src/utils/backend.js
+++ b/src/utils/backend.js
@@ -1,28 +1,8 @@
-export const wrapTry = async (promise) => {
-  try {
-    return promise.then((res) => {
-      if (!res) {
-        console.error(new Error('Response is undefined'));
-        return null;
-      }
-      if (!res.ok) throw new Error(`Request failed with ${res.status}`);
-      return res.json();
-    }).catch((error) => {
-      console.error(error);
-      return null;
-    });
-  } catch (error) {
-    console.error(error);
-    return null;
-  }
-};
+import { fetchJson } from '.';
 
-const backendFetch = (path, ...args) => wrapTry(
-  fetch(`${process.env.VUE_APP_BACKEND_URL}/${path}`, ...args).catch((err) => console.error(err)),
+const backendFetch = (path, ...args) => fetchJson(
+  `${process.env.VUE_APP_BACKEND_URL}/${path}`, ...args,
 );
-
-const backendFetchNoTimeout = (path, ...args) => fetch(`${process.env.VUE_APP_BACKEND_URL}/${path}`, ...args)
-  .catch((err) => console.error(err));
 
 export default class Backend {
   static getTipComments = async (tipId) => backendFetch(`comment/api/tip/${encodeURIComponent(tipId)}`);
@@ -106,7 +86,7 @@ export default class Backend {
     return backendFetch(`tips${query}`);
   };
 
-  static addToken = async (address) => backendFetchNoTimeout('tokenCache/addToken', {
+  static addToken = async (address) => backendFetch('tokenCache/addToken', {
     method: 'post',
     body: JSON.stringify({ address }),
     headers: { 'Content-Type': 'application/json' },
@@ -127,7 +107,8 @@ export default class Backend {
     if (ordering) queryParams.set('ordering', ordering);
     if (direction) queryParams.set('direction', direction);
     if (search) queryParams.set('search', search);
-    return process.env.VUE_APP_CONTRACT_V2_ADDRESS ? backendFetch(`tokenCache/wordRegistry?${queryParams.toString()}`) : Promise.resolve({});
+    return process.env.VUE_APP_CONTRACT_V2_ADDRESS
+      ? backendFetch(`tokenCache/wordRegistry?${queryParams.toString()}`) : Promise.resolve([]);
   }
 
   static getWordSaleVotesDetails = async (address) => backendFetch(`tokenCache/wordSaleVotesDetails/${address}`);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -33,7 +33,7 @@ export const validateTipUrl = (urlAsString) => {
   try {
     const url = toURL(urlAsString);
     return ['http:', 'https:'].includes(url.protocol) && isFQDN(url.hostname);
-  } catch (e) {
+  } catch {
     return false;
   }
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -66,3 +66,9 @@ export const blockToDate = (goalBlock, height) => {
   const diff = goalBlock - height;
   return new Date(diff * 180000 + Date.now());
 };
+
+export const fetchJson = async (...args) => {
+  const response = await fetch(...args);
+  if (!response.ok) throw new Error(`Request failed with ${response.status}`);
+  return response.json();
+};

--- a/src/views/TipsAndComments.vue
+++ b/src/views/TipsAndComments.vue
@@ -123,7 +123,7 @@ export default {
           ? 'backend/reloadComment' : 'backend/reloadTip', this.id || this.tipId);
       } catch (error) {
         this.error = true;
-        throw error;
+        console.error(error);
       } finally {
         this.showLoading = false;
       }


### PR DESCRIPTION
Known exceptions:

```
[Vue warn]: Error in mounted hook (Promise/async): "Error: Request failed with 400"

found in

---> <WordDetail> at src/views/WordDetail.vue
       <App> at src/App.vue
         <Root>
```
when opening details of word with a space in the name (https://github.com/aeternity/tipping-community-backend/issues/368)

---
```
GET https://testnet.superhero.aeternity.art/profile/image/ak_2UGL6qArnbWx9fEkJyszssMkCjpu3VeLFBPA6MXYV3APfDSz1k 404
```
Chrome always report 404 even if they handled, we can't avoid it

---

I'm proposing a way how errors should be handled:
- don't throw an error if it is somehow indicated in ui (red color or a separate modal window)
- if an error indicated somehow, it may be printed to console (to be able to debug it in production)

Later all not caught exceptions will show modal asking the user to report it. So we shouldn't have unhandled exceptions, at the same time we shouldn't handle them in a too general fashion (like I'm removing in this PR `.catch(() => null)`).

How to test this PR:
- try all features
- ensure that all of them works correctly
- report about all exceptions in console (red-colored) that weren't indicated in UI and not mentioned in the list above

fixes #707 