### PR TITLE
refactor(TipRecord): use plain link

### DIFF
--- a/src/components/AlertModal.vue
+++ b/src/components/AlertModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="modal-mask"
-    @click.stop="resolve"
+    @click="resolve"
   >
     <div class="modal-wrapper">
       <div class="success-modal">

--- a/src/components/CookiesDialog.vue
+++ b/src/components/CookiesDialog.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="cookies-dialog"
-    @click.stop
-  >
+  <div class="cookies-dialog">
     <ButtonPlain
       class="button-cancel"
       @click="$emit('close', $event)"
@@ -55,7 +52,6 @@ export default {
   border: 1px solid $article_content_color;
   border-radius: 0.25rem;
   padding: 0.9rem;
-  cursor: default;
   box-shadow: 4px 4px 4px 0 rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;

--- a/src/components/tipRecords/AuthorAndDate.vue
+++ b/src/components/tipRecords/AuthorAndDate.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="author-and-date"
-    @click.stop
-  >
+  <div class="author-and-date">
     <Author :address="address" />
     <span class="right">
       <FormatDate v-bind="$attrs" />

--- a/src/components/tipRecords/SoundCloudEmbed.vue
+++ b/src/components/tipRecords/SoundCloudEmbed.vue
@@ -65,6 +65,10 @@ export default {
   img {
     width: 35%;
     object-fit: cover;
+
+    @include smallest {
+      max-height: 150px;
+    }
   }
 
   .tip-url-details {

--- a/src/components/tipRecords/SoundCloudEmbed.vue
+++ b/src/components/tipRecords/SoundCloudEmbed.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="sound-cloud-embed"
-    :class="{ 'dialog-inside': showCookiesDialog && !isAllowed }"
-  >
+  <div class="sound-cloud-embed">
     <CookiesDialog
       v-if="showCookiesDialog && !isAllowed"
       scope="SoundCloud"
@@ -14,14 +11,17 @@
       :title="tipPreviewTitle"
       :description="tipPreviewDescription"
     >
+      <a
+        :href="tipUrl"
+        target="_blank"
+      />
       <PlayButton
         v-if="!isPlaying"
-        @click.stop="isAllowed ? isPlaying = true : showCookiesDialog = true"
+        @click="isAllowed ? isPlaying = true : showCookiesDialog = true"
       />
       <SoundCloudPlayer
         v-else-if="isPlaying && isAllowed"
         :tip-url="tipUrl"
-        @click.stop
       />
     </TipUrlDetails>
   </div>
@@ -60,18 +60,31 @@ export default {
 <style lang="scss" scoped>
 .sound-cloud-embed {
   display: flex;
-
-  &.dialog-inside {
-    position: relative;
-  }
+  position: relative;
 
   img {
     width: 35%;
     object-fit: cover;
   }
 
-  .tip-url-details ::v-deep .description {
-    @include truncate-overflow-mx(3);
+  .tip-url-details {
+    ::v-deep .description {
+      @include truncate-overflow-mx(3);
+    }
+
+    a::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+
+    .play-button,
+    .sound-cloud-player {
+      position: relative;
+    }
   }
 }
 </style>

--- a/src/components/tipRecords/SoundCloudEmbed.vue
+++ b/src/components/tipRecords/SoundCloudEmbed.vue
@@ -68,6 +68,8 @@ export default {
   }
 
   .tip-url-details {
+    min-width: 0;
+
     ::v-deep .description {
       @include truncate-overflow-mx(3);
     }

--- a/src/components/tipRecords/SoundCloudPlayer.vue
+++ b/src/components/tipRecords/SoundCloudPlayer.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="sound-cloud-player"
-    @click.stop
-  >
+  <div class="sound-cloud-player">
     <iframe
       ref="iframe"
       class="soundcloud-iframe"
@@ -13,7 +10,7 @@
       class="play-button"
       :is-playing="isPlaying"
       :loading="loading"
-      @click.stop="togglePlay"
+      @click="togglePlay"
     />
     <template v-else>
       Playback error

--- a/src/components/tipRecords/TipMedia.vue
+++ b/src/components/tipRecords/TipMedia.vue
@@ -9,7 +9,7 @@
       :style="{ 'grid-area': `pos${index}` }"
       :src="image"
       loading="lazy"
-      @click.stop="openImageGallery(index)"
+      @click="openImageGallery(index)"
       @error="$event.target.src = defaultImage"
     >
     <span

--- a/src/components/tipRecords/TipPreview.vue
+++ b/src/components/tipRecords/TipPreview.vue
@@ -11,6 +11,7 @@
     />
     <TipPreviewImage
       v-else-if="isPreviewToBeVisualized"
+      :tip-url="tipUrl"
       :image="tipPreviewImage"
       :source="sourceUrl"
       :title="tipPreviewTitle"
@@ -30,13 +31,9 @@
       </div>
     </TipUrlDetails>
 
-    <div
-      class="actions"
-      @click.stop
-    >
+    <div class="actions">
       <TipInput :tip="tip" />
       <a
-        v-if="tipUrl"
         target="_blank"
         :href="tipUrl"
       >
@@ -117,14 +114,26 @@ export default {
   background-color: $thumbnail_background_color_alt;
   border-radius: 0.5rem;
   font-size: 0.75rem;
-  cursor: pointer;
   color: #babac0;
   line-height: 1.1rem;
-  overflow: hidden;
 
   &:hover {
     background-color: #373843;
     color: #c6c6cc;
+  }
+
+  // TODO: add `overflow: hidden` after making dropdowns appearing in a separate node
+  // to don't duplicate border-radius, and better margins
+  ::v-deep .tip-preview-image,
+  ::v-deep .tip-preview-image > img,
+  ::v-deep .you-tube-embed > iframe, {
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
+  }
+
+  ::v-deep .sound-cloud-embed > img,
+  ::v-deep .twitter-embed > img {
+    border-top-left-radius: 0.5rem;
   }
 
   .no-preview {
@@ -135,7 +144,7 @@ export default {
     display: flex;
     align-items: center;
     margin-top: 0.25rem;
-    margin-bottom: 0.2rem;
+    padding-bottom: 0.2rem; // TODO: replace with margin after adding `overflow: hidden`
 
     .tip-input {
       flex-shrink: 0;

--- a/src/components/tipRecords/TipPreviewImage.vue
+++ b/src/components/tipRecords/TipPreviewImage.vue
@@ -1,23 +1,27 @@
 <template>
-  <div class="tip-preview-image">
+  <Link
+    class="tip-preview-image"
+    :to="tipUrl"
+  >
     <img
       :src="image"
       loading="lazy"
       @error="$event.target.src = defaultImage"
     >
     <TipUrlDetails v-bind="$attrs" />
-    <slot />
-  </div>
+  </Link>
 </template>
 
 <script>
+import Link from '../Link.vue';
 import TipUrlDetails from './TipUrlDetails.vue';
 import defaultImage from '../../assets/defaultImg.svg';
 
 export default {
-  components: { TipUrlDetails },
+  components: { Link, TipUrlDetails },
   inheritAttrs: false,
   props: {
+    tipUrl: { type: String, required: true },
     image: { type: String, default: defaultImage },
   },
   data: () => ({ defaultImage }),
@@ -27,6 +31,7 @@ export default {
 <style lang="scss" scoped>
 .tip-preview-image {
   background: #000;
+  display: block;
   position: relative;
 
   img {

--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -1,8 +1,9 @@
 <template>
-  <div
-    class="tip-record"
-    @click="goToTip"
-  >
+  <div class="tip-record">
+    <RouterLink
+      v-if="!detailed"
+      :to="toTip"
+    />
     <AuthorAndDate
       :date="tip.timestamp"
       :address="tip.sender"
@@ -36,19 +37,13 @@
       :tip="tip"
       :tip-url="tipUrl"
     />
-    <div
-      class="actions"
-      @click.stop
-    >
+    <div class="actions">
       <TipInput
         v-if="tip.type === 'POST_WITHOUT_TIP'"
         :tip="{ ...tip, url: `https://superhero.com/tip/${tip.id}` }"
       />
       <span v-else />
-      <ButtonFeed
-        :disabled="detailed"
-        @click.stop="$router.push(toTip)"
-      >
+      <ButtonFeed disabled>
         <IconComment slot="icon" />
         {{ tip.commentCount }}
       </ButtonFeed>
@@ -149,12 +144,6 @@ export default {
       );
       await this.$store.dispatch('updatePinnedItems');
     },
-    goToTip() {
-      if (this.detailed) {
-        return this.tipUrl ? window.open(this.tipUrl) : null;
-      }
-      return this.$router.push(this.toTip);
-    },
   },
 };
 </script>
@@ -164,11 +153,29 @@ export default {
   background-color: $light_color;
   padding: 1rem 1rem 0.75rem 1rem;
   margin-bottom: 0.15rem;
-  cursor: pointer;
+  position: relative;
 
   @include smallest {
     padding: 0.5rem;
     margin-bottom: 0.5rem;
+  }
+
+  > a::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+
+  .author-and-date ::v-deep .author,
+  .author-and-date .three-dots-menu,
+  .tip-title ::v-deep .topic,
+  .tip-media,
+  .tip-preview,
+  .tip-input {
+    position: relative;
   }
 
   .actions {

--- a/src/components/tipRecords/TipTitle.vue
+++ b/src/components/tipRecords/TipTitle.vue
@@ -5,7 +5,6 @@
         v-if="part.matches"
         :key="id"
         :topic="part.text"
-        @click.native.stop
       />
       <template v-else>
         {{ part.text }}

--- a/src/components/tipRecords/TipUrlDetails.vue
+++ b/src/components/tipRecords/TipUrlDetails.vue
@@ -4,7 +4,7 @@
       {{ source }}
     </div>
     <h2
-      class="title text-ellipsis"
+      class="title"
       :title="title"
     >
       {{ title }}
@@ -47,6 +47,8 @@ export default {
     margin: 0 0 0.15rem 0;
     color: $tip_note_color;
     line-height: 0.9rem;
+
+    @include text-ellipsis;
   }
 
   .description {

--- a/src/components/tipRecords/TwitterEmbed.vue
+++ b/src/components/tipRecords/TwitterEmbed.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="twitter-embed">
+  <a
+    class="twitter-embed"
+    :href="tipUrl"
+    target="_blank"
+  >
     <img :src="tipPreviewImage">
 
     <TipUrlDetails
@@ -7,7 +11,7 @@
       :title="tipPreviewTitle"
       :description="tipPreviewDescription"
     />
-  </div>
+  </a>
 </template>
 
 <script>
@@ -19,6 +23,7 @@ export default {
     tipPreviewTitle: { type: String, required: true },
     tipPreviewDescription: { type: String, required: true },
     tipPreviewImage: { type: String, required: true },
+    tipUrl: { type: String, required: true },
     sourceUrl: { type: String, default: '' },
   },
 };

--- a/src/components/tipRecords/TwitterEmbed.vue
+++ b/src/components/tipRecords/TwitterEmbed.vue
@@ -36,6 +36,10 @@ export default {
   img {
     width: 35%;
     object-fit: cover;
+
+    @include smallest {
+      max-height: 150px;
+    }
   }
 
   .tip-url-details {

--- a/src/components/tipRecords/TwitterEmbed.vue
+++ b/src/components/tipRecords/TwitterEmbed.vue
@@ -38,11 +38,15 @@ export default {
     object-fit: cover;
   }
 
-  .tip-url-details ::v-deep .description {
-    @include truncate-overflow-mx(6);
+  .tip-url-details {
+    min-width: 0;
 
-    @include mobile {
-      @include truncate-overflow-mx(3);
+    ::v-deep .description {
+      @include truncate-overflow-mx(6);
+
+      @include mobile {
+        @include truncate-overflow-mx(3);
+      }
     }
   }
 }

--- a/src/components/tipRecords/YouTubeEmbed.vue
+++ b/src/components/tipRecords/YouTubeEmbed.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="you-tube-embed"
-    :class="{ 'dialog-inside': showCookiesDialog && !isAllowed }"
-  >
+  <div class="you-tube-embed">
     <CookiesDialog
       v-if="showCookiesDialog && !isAllowed"
       scope="YouTube"
@@ -20,17 +17,18 @@
         picture-in-picture"
       allowfullscreen
     />
-    <TipPreviewImage
-      v-if="!isPlaying"
-      :image="`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`"
-      :source="sourceUrl"
-      :title="tipPreviewTitle"
-      :description="tipPreviewDescription"
-    >
-      <PlayButton
-        @click.stop="isAllowed ? isPlaying = true : showCookiesDialog = true"
+    <template v-if="!isPlaying">
+      <TipPreviewImage
+        :tip-url="tipUrl"
+        :image="`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`"
+        :source="sourceUrl"
+        :title="tipPreviewTitle"
+        :description="tipPreviewDescription"
       />
-    </TipPreviewImage>
+      <PlayButton
+        @click="isAllowed ? isPlaying = true : showCookiesDialog = true"
+      />
+    </template>
   </div>
 </template>
 
@@ -67,9 +65,7 @@ export default {
 
 <style lang="scss" scoped>
 .you-tube-embed {
-  &.dialog-inside {
-    position: relative;
-  }
+  position: relative;
 
   iframe {
     display: block;
@@ -79,7 +75,7 @@ export default {
     @include feed-preview-height;
   }
 
-  .tip-preview-image .play-button {
+  .play-button {
     position: absolute;
     left: 50%;
     top: 50%;


### PR DESCRIPTION
Approach from #1129 applied to TipRecord based on #1135

The only significant change is that the preview always points to a link that this preview for instead of a link to tip comments. This looks reasonable and was easier to implement. @onvisions is it acceptable?

@Liubov-crypto ensure that all kinds of tips behave the same as before except for the issue mentioned above.